### PR TITLE
process 模块改为env的一个成员

### DIFF
--- a/behavior3/behavior_node.lua
+++ b/behavior3/behavior_node.lua
@@ -38,7 +38,8 @@ function mt:run(env)
     for i, var_name in ipairs(self.data.input or {}) do
         vars[i] = env:get_var(var_name)
     end
-    local func = assert(process[self.name].run, self.name)
+
+    local func = assert(env.process[self.name].run, self.name)
     if self.data.input then
         vars = table.pack(func(self, env, table.unpack(vars, 1, #self.data.input)))
     else
@@ -80,7 +81,5 @@ local M = {}
 function M.new(...)
     return new_node(...)
 end
-function M.process(custom)
-    process = custom
-end
+
 return M

--- a/behavior3/behavior_tree.lua
+++ b/behavior3/behavior_tree.lua
@@ -65,10 +65,15 @@ local function new_env(params)
         inner_vars = {}, -- [k.."_"..node.id] => vars
         vars = {},
         stack = {},
-        last_ret = nil
+        last_ret = nil,
+        process = nil,
     }
     for k, v in pairs(params) do
         env[k] = v
+    end
+
+    if not env.process then
+        env.process = require('behavior3.sample_process')
     end
 
     function env:get_var(k)

--- a/test.lua
+++ b/test.lua
@@ -1,7 +1,6 @@
 
 local behavior_tree = require "behavior3.behavior_tree"
 local behavior_node = require "behavior3.behavior_node"
-behavior_node.process(require "example.process")
 
 local json = require "json"
 
@@ -44,6 +43,7 @@ local function test_hero()
     local btree = behavior_tree.new("hero", load_tree("workspace/trees/hero.json"), {
         ctx   = ctx,
         owner = hero,
+        process = require("example.process"),
     })
 
     -- 移动到目标并攻击
@@ -70,6 +70,7 @@ local function test_moster()
     local btree = behavior_tree.new("monster", load_tree("workspace/trees/monster.json"), {
         ctx   = ctx,
         owner = monster,
+        process = require("example.process"),
     })
 
     monster.hp = 100


### PR DESCRIPTION
* 使用skynet宿主程序（而非纯lua程序）驱动行为树时，使用 behavior_node.process(require "my_process") 并不会生效
* 在此将process 改为env的一个成员变量
* 注意：热更新时也需要进行process的替换。