### PR TITLE
Unexpect status in Parallel Node

### DIFF
--- a/behavior3/nodes/actions/wait_for_count.lua
+++ b/behavior3/nodes/actions/wait_for_count.lua
@@ -1,0 +1,37 @@
+-- WaitForCount
+--
+
+local bret = require 'behavior3.behavior_ret'
+
+---@type BehaviorNodeDefine
+local M = {
+    name = 'WaitForCount',
+    type = 'Action',
+    desc = '等待特定次数',
+    args = {
+        {
+            name = 'tick',
+            type = 'int',
+            desc = 'tick'
+        }
+    },
+    run = function(node, env)
+        local args = node.args
+        local t = node:resume(env)
+        if t then
+            t = t - 1
+            if t <= 0 then
+                print('DONE')
+                return bret.SUCCESS
+            else
+                print('CONTINUE', "node#" .. node.data.id .. "Last tick", t)
+                node:yield(env, t)
+                return bret.RUNNING
+            end
+        end
+        print('WaitForCount', args.tick)
+        return node:yield(env, args.tick)
+    end
+}
+
+return M

--- a/behavior3/nodes/composites/parallel.lua
+++ b/behavior3/nodes/composites/parallel.lua
@@ -29,12 +29,9 @@ local M = {
                     env:push_stack(child)
                     status = child:run(env)
                     if status == bret.RUNNING then
-                        rev = {}
+                        p = #nodes + 1
                         while #env.stack > level do
-                            table.insert(rev, env:pop_stack())
-                        end
-                        while #rev > 0 do
-                            table.insert(nodes, table.remove(rev))
+                            table.insert(nodes, p, env:pop_stack())
                         end
                         break
                     end

--- a/behavior3/nodes/composites/parallel.lua
+++ b/behavior3/nodes/composites/parallel.lua
@@ -24,15 +24,19 @@ local M = {
             if nodes == nil then
                 status = child:run(env)
             elseif #nodes > 0 then
-                for j = #nodes, 1, -1 do
-                    child = nodes[j]
+                while #nodes > 0 do
+                    child = table.remove(nodes)
                     env:push_stack(child)
                     status = child:run(env)
                     if status == bret.RUNNING then
-                        env:pop_stack()
+                        rev = {}
+                        while #env.stack > level do
+                            table.insert(rev, env:pop_stack())
+                        end
+                        while #rev > 0 do
+                            table.insert(nodes, table.remove(rev))
+                        end
                         break
-                    else
-                        table.remove(nodes, j)
                     end
                 end
             else
@@ -42,9 +46,9 @@ local M = {
             if status == bret.RUNNING then
                 if nodes == nil then
                     nodes = {}
-                    while #env.stack > level do
-                        table.insert(nodes, 1, env:pop_stack())
-                    end
+                end
+                while #env.stack > level do
+                    table.insert(nodes, 1, env:pop_stack())
                 end
             else
                 nodes = {}

--- a/behavior3/sample_process.lua
+++ b/behavior3/sample_process.lua
@@ -35,4 +35,5 @@ return {
   RandomIndex        = require "behavior3.nodes.actions.random_index",
   Wait               = require "behavior3.nodes.actions.wait",
   Concat             = require "behavior3.nodes.actions.concat",
+  WaitForCount       = require "behavior3.nodes.actions.wait_for_count",
 }

--- a/example/process.lua
+++ b/example/process.lua
@@ -29,6 +29,7 @@ return {
     ForEach      = require "behavior3.nodes.actions.foreach",
     Log          = require "behavior3.nodes.actions.log",
     Wait         = require "behavior3.nodes.actions.wait",
+    WaitForCount = require "behavior3.nodes.actions.wait_for_count",
     Now          = require "behavior3.nodes.actions.now",
     Clear        = require "behavior3.nodes.actions.clear",
     GetHp        = require "example.actions.get_hp",

--- a/test.lua
+++ b/test.lua
@@ -132,3 +132,14 @@ local function test_repeat_until_fail()
 end
 
 test_repeat_until_fail()
+
+local function test_parallel_with_wait()
+    print("=================== test parallel with wait ========================")
+    local btree = behavior_tree.new("parallel-with-wait", load_tree("workspace/trees/test-parallel-with-wait.json"), {
+    })
+    for i = 1, 8 do
+        btree:run()
+    end
+end
+
+test_parallel_with_wait()

--- a/workspace/trees/test-parallel-with-wait.json
+++ b/workspace/trees/test-parallel-with-wait.json
@@ -1,0 +1,64 @@
+{
+  "name": "test-parallel-with-wait",
+  "root": {
+    "id": 1,
+    "name": "Sequence",
+    "children": [
+      {
+        "id": 2,
+        "name": "Parallel",
+        "children": [
+          {
+            "id": 3,
+            "name": "Sequence",
+            "children": [
+              {
+                "id": 4,
+                "name": "WaitForCount",
+                "args": {
+                  "tick": 1
+                }
+              },
+              {
+                "id": 5,
+                "name": "WaitForCount",
+                "args": {
+                  "tick": 1
+                }
+              }
+            ]
+          },
+          {
+            "id": 6,
+            "name": "Sequence",
+            "children": [
+              {
+                "id": 7,
+                "name": "WaitForCount",
+                "args": {
+                  "tick": 1
+                }
+              },
+              {
+                "id": 8,
+                "name": "WaitForCount",
+                "args": {
+                  "tick": 2
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": 9,
+        "name": "Log",
+        "args": {
+          "message": "End test parallel with wait"
+        }
+      }
+    ]
+  },
+  "export": true,
+  "desc": ""
+}


### PR DESCRIPTION
## 背景

Parallel 节点具有并行执行的功能，内部需要自行维护运行栈帧。  
其在子节点进入 Running 状态后，将其收揽于自身的运行栈中，从而在 BehaviorTree 的下次运行中，直接进入 Parallel 节点，从而允许在自身内部实现并行执行的效果。

然而，现有的 Parallel 节点的实现并未考虑子树内部的 Running 状态与更多副作用。一旦子树中的某节点退出 Running 态，并在后续的执行中增长了更多的节点，那么 Parallel 将抛出状态非预期错误。

![1722100642492](https://github.com/user-attachments/assets/24093975-aa7c-456a-be3d-93c353372b22)

## 功能

该提交是一个修复提交，解决了上述问题，未带来更多功能。

## 核心变化

在 Parallel 的实现中，改用了如下逻辑。

```lua
while #nodes > 0 do
    child = table.remove(nodes)
    env:push_stack(child)
    status = child:run(env)
    if status == bret.RUNNING then
        p = #nodes + 1
        while #env.stack > level do
            table.insert(nodes, p, env:pop_stack())
        end
        break
    end
end
```

该逻辑考虑了子树内部的更复杂的栈变化。

我是 Lua 纯新手，对于 Lua 的语法和语义并不熟悉，因此我无法绝对保证这段代码的正确性。但我编写并通过了测试，姑且认为这段代码是更正确的。  
实际上我正在为 Behavior3lua 进行面向 TypeScript 的重构，以期获得更完善的类型检查，目前仍在开发中。  
当前分支的代码在某些地方仍有细微差错，后续我将尽可能发起 Pr 与 Issue。然而我不会对 Behavior3lua 进行更多直接地维护，因为 EmmyLua 断点调试体验实在是太糟糕了，它总是失去连接。

再次感谢您的辛勤工作。